### PR TITLE
refs #198: fix for iOS 5.1+ iCloud backup exclusion

### DIFF
--- a/Classes/MapBoxAppDelegate.m
+++ b/Classes/MapBoxAppDelegate.m
@@ -224,13 +224,22 @@
         {
             if ([enumeratedURL isFileURL])
             {
-                const char *filePath = [[enumeratedURL path] fileSystemRepresentation];
-                
-                const char *attrName = "com.apple.MobileBackup"; // attribute means "do not backup"
-                
-                u_int8_t attrValue = [[NSUserDefaults standardUserDefaults] boolForKey:@"excludeiCloudBackup"] ? 1 : 0;
-                
-                setxattr(filePath, attrName, &attrValue, sizeof(attrValue), 0, 0);
+                if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"5.0.1") && SYSTEM_VERSION_LESS_THAN(@"5.1"))
+                {
+                    const char *filePath = [[enumeratedURL path] fileSystemRepresentation];
+                    
+                    const char *attrName = "com.apple.MobileBackup"; // attribute means "do not backup"
+                    
+                    u_int8_t attrValue = [[NSUserDefaults standardUserDefaults] boolForKey:@"excludeiCloudBackup"] ? 1 : 0;
+                    
+                    setxattr(filePath, attrName, &attrValue, sizeof(attrValue), 0, 0);
+                }
+                else if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"5.1"))
+                {
+                    [enumeratedURL setResourceValue:[[NSUserDefaults standardUserDefaults] objectForKey:@"excludeiCloudBackup"] 
+                                             forKey:NSURLIsExcludedFromBackupKey 
+                                              error:NULL];
+                }
             }
         }
     }


### PR DESCRIPTION
Holding here until 5.1 SDK goes stable. See #198. 
